### PR TITLE
Fix: Configure Pa11y to use .pa11yci URLs

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Run pa11y
         run: |
           npm install -g pa11y-ci
-          pa11y-ci --json https://mitesh411.github.io/MyResume/ 
+          pa11y-ci --json


### PR DESCRIPTION
Modified the GitHub workflow to ensure pa11y-ci uses the URLs specified in the .pa11yci configuration file by removing the explicit URL from the command-line invocation. This makes the accessibility scan target the intended URLs.