### PR TITLE
Modernize Pa11y CI workflow and pin npm tooling versions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -17,36 +17,19 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4.4.0
         with:
-          node-version: '18'
+          node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm install
 
-      - name: Install Pa11y CI locally
-        run: npm install --save-dev pa11y-ci
-
-      - name: Add fallback start script if missing
-        run: |
-          if ! npm run | grep -q "start"; then
-            echo '{ "scripts": { "start": "npx http-server ." } }' > temp-package.json
-            jq -s '.[0] * .[1]' package.json temp-package.json > package.tmp.json
-            mv package.tmp.json package.json
-            rm temp-package.json
-          fi
-
       - name: Run local server
         run: |
-          npm run start &  # Make sure this actually starts your app!
+          npm run start &
           sleep 5
 
       - name: Run Pa11y CI
-        run: npx pa11y-ci --json > pa11y-report.json
-        env:
-          PUPPETEER_EXECUTABLE_PATH: ""
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "false"
-          # Pass Chromium flags for no-sandbox
-          CHROME_PATH: "/usr/bin/google-chrome"
-          PA11Y_CHROMIUM_LAUNCH_ARGS: "--no-sandbox --disable-setuid-sandbox"
+        run: npm run a11y -- --json > pa11y-report.json
 
       - name: Upload Pa11y report as artifact
         uses: actions/upload-artifact@v4

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,9 +1,17 @@
 {
+  "defaults": {
+    "standard": "WCAG2AA",
+    "timeout": 30000,
+    "wait": 1000
+  },
   "urls": [
-    "https://pa11y.org/",
-    "https://pa11y.org/contributing"
+    "http://127.0.0.1:8080/",
+    "http://127.0.0.1:8080/README.md"
   ],
   "chromeLaunchConfig": {
-    "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+    "args": [
+      "--no-sandbox",
+      "--disable-setuid-sandbox"
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # AXEDemo
+
+## Accessibility checks
+
+This project uses **pa11y-ci** to run automated accessibility checks.
+
+### Local usage
+
+```bash
+npm install
+npm run start
+npm run a11y
+```
+
+### Tooling versions
+
+- Node.js: `>=20`
+- pa11y-ci: `^4.0.1`
+- http-server: `^14.1.1`

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "axedemo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Accessibility checks using pa11y-ci",
+  "scripts": {
+    "start": "http-server . -p 8080 -c-1 --silent",
+    "a11y": "pa11y-ci"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1",
+    "pa11y-ci": "^4.0.1"
+  }
+}


### PR DESCRIPTION
### Motivation
- Bring the Pa11y CI setup up to date and make the project self-contained by declaring Node engine and npm devDependencies. 
- Target accessibility checks at a locally served instance instead of external sites so CI validates the repository content. 
- Simplify and modernize the GitHub Actions workflow to rely on project scripts and enable npm caching for faster, more reproducible runs.

### Description
- Add a `package.json` with `engines.node` set to `>=20`, `devDependencies` for `pa11y-ci` and `http-server`, and `start`/`a11y` npm scripts. 
- Update `.pa11yci` to include `defaults` (`WCAG2AA`, `timeout`, `wait`) and use local URLs (`http://127.0.0.1:8080/` and `/README.md`) while preserving sandbox-safe Chrome args. 
- Replace the previous workflow steps that relied on `npx pa11y-ci` and ad-hoc fallbacks with a cleaned GitHub Actions workflow that uses Node 20, enables `cache: 'npm'`, runs `npm install`, starts the local server via `npm run start`, and runs Pa11y via `npm run a11y`. 
- Update `README.md` with local usage instructions and declared tooling versions.

### Testing
- Ran `node -v && npm -v` to validate runtime versions and the environment, which succeeded. 
- Validated JSON files with `jq . .pa11yci` and `jq . package.json` and ran `git diff --check`, all of which succeeded. 
- Attempted `npm install` to verify dependency installation but it failed in this environment due to a `403 Forbidden` response from the npm registry, so package installation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3bf50fd70832f95e57e95fe7b673b)