### PR TITLE
Add Pa11y CI workflow, package.json, and config for local accessibility checks

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -12,41 +12,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@v5
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm install
 
-      - name: Install Pa11y CI locally
-        run: npm install --save-dev pa11y-ci
-
-      - name: Add fallback start script if missing
-        run: |
-          if ! npm run | grep -q "start"; then
-            echo '{ "scripts": { "start": "npx http-server ." } }' > temp-package.json
-            jq -s '.[0] * .[1]' package.json temp-package.json > package.tmp.json
-            mv package.tmp.json package.json
-            rm temp-package.json
-          fi
-
       - name: Run local server
         run: |
-          npm run start &  # Make sure this actually starts your app!
+          npm run start &
           sleep 5
 
       - name: Run Pa11y CI
-        run: npx pa11y-ci --json > pa11y-report.json
-        env:
-          PUPPETEER_EXECUTABLE_PATH: ""
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "false"
-          # Pass Chromium flags for no-sandbox
-          CHROME_PATH: "/usr/bin/google-chrome"
-          PA11Y_CHROMIUM_LAUNCH_ARGS: "--no-sandbox --disable-setuid-sandbox"
+        run: npm run a11y -- --json > pa11y-report.json
 
       - name: Upload Pa11y report as artifact
         uses: actions/upload-artifact@v4

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,9 +1,17 @@
 {
+  "defaults": {
+    "standard": "WCAG2AA",
+    "timeout": 30000,
+    "wait": 1000
+  },
   "urls": [
-    "https://pa11y.org/",
-    "https://pa11y.org/contributing"
+    "http://127.0.0.1:8080/",
+    "http://127.0.0.1:8080/README.md"
   ],
   "chromeLaunchConfig": {
-    "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+    "args": [
+      "--no-sandbox",
+      "--disable-setuid-sandbox"
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # AXEDemo
+
+## Accessibility checks
+
+This project uses **pa11y-ci** to run automated accessibility checks.
+
+### Local usage
+
+```bash
+npm install
+npm run start
+npm run a11y
+```
+
+### Tooling versions
+
+- Node.js: `>=22`
+- pa11y-ci: `^4.0.1`
+- http-server: `^14.1.1`

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "axedemo",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Accessibility checks using pa11y-ci",
+  "scripts": {
+    "start": "http-server . -p 8080 -c-1 --silent",
+    "a11y": "pa11y-ci"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1",
+    "pa11y-ci": "^4.0.1"
+  }
+}


### PR DESCRIPTION
### Motivation

- Add automated accessibility checks using `pa11y-ci` and make them run in CI for pushes and pull requests to `main`.
- Standardize tooling by requiring a Node.js `>=22` runtime and using reusable npm scripts for start and a11y tasks.
- Simplify the workflow and local configuration to target a local server instead of external pa11y.org pages.

### Description

- Updated GitHub Actions workflow to use `actions/checkout@v5`, `actions/setup-node@v5`, and Node.js `22`, and to run `npm run a11y` to produce `pa11y-report.json`.
- Removed ad-hoc pa11y installation and fallback start-script injection from the workflow and instead added a `package.json` with `start` and `a11y` scripts plus `http-server` and `pa11y-ci` devDependencies.
- Added a `.pa11yci` file with sensible defaults (`WCAG2AA`, `timeout`, `wait`), local URLs (`http://127.0.0.1:8080/`), and Chrome launch args.
- Updated `README.md` with local usage instructions and tooling version requirements.

### Testing

- No automated tests were executed as part of this change; the updated workflow is configured to run `pa11y-ci` on future pushes and pull requests to `main`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3bf50fd70832f95e57e95fe7b673b)