### PR TITLE
Fix pa11y-ci chromeLaunchConfig placement

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -2,16 +2,16 @@
   "defaults": {
     "standard": "WCAG2AA",
     "timeout": 30000,
-    "wait": 1000
+    "wait": 1000,
+    "chromeLaunchConfig": {
+      "args": [
+        "--no-sandbox",
+        "--disable-setuid-sandbox"
+      ]
+    }
   },
   "urls": [
     "http://127.0.0.1:8080/",
     "http://127.0.0.1:8080/README.md"
-  ],
-  "chromeLaunchConfig": {
-    "args": [
-      "--no-sandbox",
-      "--disable-setuid-sandbox"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
Fix pa11y-ci chromeLaunchConfig placement

Move `chromeLaunchConfig` to the `defaults` section in `.pa11yci` so that the `--no-sandbox` and `--disable-setuid-sandbox` arguments are properly passed to Puppeteer. This fixes the "No usable sandbox!" crash when running pa11y-ci in CI environments.

---
*PR created automatically by Jules for task [11275219360740497568](https://jules.google.com/task/11275219360740497568) started by @Mitesh411*